### PR TITLE
Remove panic implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,5 @@ version = "0.1.3"
 msp430 = "0.1.0"
 r0 = "0.2.2"
 
-[features]
-# provides a panic_fmt implementation that goes into infinite loop
-abort-on-panic = []
-
 [build-dependencies]
 rustc_version = "0.2.1"

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -1,17 +1,3 @@
-use core::panic::PanicInfo;
-
-/// Default panic handler
-#[cfg(feature = "abort-on-panic")]
-#[panic_implementation]
-fn panic(_info: &PanicInfo) -> ! {
-    // Disable interrupts to prevent further damage.
-    ::msp430::interrupt::disable();
-    loop {
-        // Prevent optimizations that can remove this loop.
-        ::msp430::asm::barrier();
-    }
-}
-
 // Lang item required to make the normal `main` work in applications
 //
 // This is how the `start` lang item works:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,6 @@
 //!
 //! - Before main initialization of the `.bss` and `.data` sections.
 //!
-//! - A `panic_fmt` implementation that just calls abort that you can opt into
-//!   through the "abort-on-panic" Cargo feature. If you don't use this feature
-//!   you'll have to provide the `panic_fmt` lang item yourself. Documentation
-//!   [here](https://doc.rust-lang.org/unstable-book/language-features/lang-items.html)
-//!
 //! - A minimal `start` lang item to support the standard `fn main()`
 //!   interface. (NOTE: The processor goes into infinite loop after
 //!   returning from `main`)
@@ -41,7 +36,6 @@
 //! $ # add this crate as a dependency
 //! $ edit Cargo.toml && cat $_
 //! [dependencies.msp430-rt]
-//! features = ["abort-on-panic"]
 //! version = "0.1.0"
 //!
 //! $ # tell Xargo which standard crates to build
@@ -273,7 +267,6 @@
 //! ```
 
 #![cfg_attr(target_arch = "msp430", feature(core_intrinsics))]
-#![cfg_attr(feature = "abort-on-panic", feature(panic_implementation))]
 #![deny(missing_docs)]
 #![feature(abi_msp430_interrupt)]
 #![feature(asm)]
@@ -344,8 +337,7 @@ unsafe extern "C" fn reset_handler() -> ! {
 
     #[link_section = ".vector_table.reset_vector"]
     #[used]
-    static RESET_VECTOR: unsafe extern "msp430-interrupt" fn() -> ! =
-        trampoline;
+    static RESET_VECTOR: unsafe extern "msp430-interrupt" fn() -> ! = trampoline;
 }
 
 #[export_name = "DEFAULT_HANDLER"]
@@ -391,5 +383,5 @@ macro_rules! default_handler {
             let f: fn() = $path;
             f();
         }
-    }
+    };
 }


### PR DESCRIPTION
This PR removes the panic implementation defined by this crate, which has been refactored into its own [panic-msp430](https://crates.io/crates/panic-msp430) crate. Since the panic_implementation feature has been removed and superseded by panic_handler, this crate's existing panic implementation could not be built using the latest nightly. However, after switching to panic_handler, the handler could only be registered by other crates if they invoked `extern crate msp430_rt`. This caused problems when building binaries that depended on msp430-rt and msp430 device crates that used msp430-rt, as the lang items defined in msp430-rt would be duplicated in the build process. The solution is to put the panic handler into its own crate and include it on its own.