### PR TITLE
Introduce optional CriticalSection arguments to main() and interrupt handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Modify `#[entry]` and `#[interrupt]` macros so that `main()` and interrupt
+  handlers accept a `CriticalSection` argument.
 
 ## [v0.2.2]- 2020-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Modify `#[entry]` and `#[interrupt]` macros so that `main()` and interrupt
-  handlers accept a `CriticalSection` argument.
+  handlers optionally accept a `CriticalSection` argument.
 
 ## [v0.2.2]- 2020-01-07
 


### PR DESCRIPTION
The proc macros `entry` and `interrupt` are modified to allow the main and interrupt handling functions to accept a single `CriticalSection` parameter. This change, along with a new `enable_with_cs(CriticalSection)` API that I've yet to implement, allows interrupts to be enabled safely from any context and reduces unnecessary calls to `interrupt::free`. Additionally, the old function signatures still work, so this is not a breaking change.