### PR TITLE
Constrain `CriticalSection` lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- In preparation for bumping the version of `bare-metal` in `msp430` to `v1.0`,
+  the `CriticalSection` parameters to the `main` and ISR functions now have
+  their lifetimes constrained to the body of their functions.
 
 ## [v0.2.5]- 2021-10-27
 


### PR DESCRIPTION
Related to https://github.com/rust-embedded/msp430/pull/9. `bare-metal` version 1.0 introduces a lifetime param on `CriticalSection` and requires that lifetime to be constrained so that it's not static. This change places such constraints on the `CriticalSection`s provided by `main` and ISRs.