### PR TITLE
Configurable vector end addr

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+# Only one target to support for all chips!
+target = "msp430-none-elf"
+
+[unstable]
+# MSP430 doesn't come with libcore compiled already. But when it does, this
+# key can be removed.
+build-std = ["core"]

--- a/link.x.in
+++ b/link.x.in
@@ -9,6 +9,9 @@ EXTERN(__RESET_VECTOR);
    object file that's passed to the linker *before* this crate */
 EXTERN(__INTERRUPTS);
 
+/* Provide a default for __VECTORS_END_ADDR. Can be overriden in the user memory.x file */
+PROVIDE(__VECTORS_END_ADDR = 0x10000);
+
 /* # Pre-initialization function */
 /* If the user overrides this using the `pre_init!` macro or by creating a `__pre_init` function,
 then the function this points to will be called before the RAM is initialized. */
@@ -78,10 +81,10 @@ SECTIONS
 }
 
 /* Do not exceed this mark in the error messages below                                    | */
-ASSERT(ORIGIN(VECTORS) + LENGTH(VECTORS) == 0x10000, "
+ASSERT(ORIGIN(VECTORS) + LENGTH(VECTORS) == __VECTORS_END_ADDR, "
 ERROR(msp430-rt): The VECTORS memory region must end at address 0x10000. Check memory.x");
 
-ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) == 0x10000, "
+ASSERT(ADDR(.vector_table) + SIZEOF(.vector_table) == __VECTORS_END_ADDR, "
 ERROR(msp430-rt): .vector_table is shorter than expected.
 Possible solutions, from most likely to less likely:
 - Link to a svd2rust generated pac crate, if you are not
@@ -89,6 +92,7 @@ Possible solutions, from most likely to less likely:
   pac crate
 - Disable the 'device' feature of msp430-rt to build a generic application; a dependency
 may be enabling it
+- Override __VECTORS_END_ADDR if your vector table is not placed at the regular vector location
 ");
 
 ASSERT(_sgot == _egot, "

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-04-29"
+components = ["rust-src"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,12 @@
 //! }
 //! ```
 //!
+//! By default, the linker will check that the address after the vector table is 0x10000 to
+//! ensure that the vector table is placed correctly. For special cases like bootloader
+//! setups, you might want to place the vector table somewhere else. For theses cases,
+//! you can re-configure the expected end address by setting `__VECTORS_END_ADDR` in your
+//! `memory.x` file.
+//!
 //! # An example
 //!
 //! This section presents a minimal application built on top of `msp430-rt`.


### PR DESCRIPTION
I still need to test this inside my bootloader/application. But if I want to avoid overwriting the bootloader vector table, I need to place the vector table somewhere else, and this is currently not possible because of the check.