### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/test-macro.yml
+++ b/.github/workflows/test-macro.yml
@@ -5,7 +5,7 @@ name: Run Macro Tests
 jobs:
   testing:
     name: testing
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/test-macro.yml
+++ b/.github/workflows/test-macro.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          override: true
+          component: rust-src
 
       - name: Test macro library
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -p msp430-rt-macros --features device
+          args: -Zbuild-std -p msp430-rt-macros --target=x86_64-unknown-linux-gnu --features device

--- a/macros/tests/compiletest.rs
+++ b/macros/tests/compiletest.rs
@@ -1,5 +1,8 @@
 #[test]
 fn ui() {
+    std::env::set_var("CARGO_BUILD_TARGET", "msp430-none-elf");
+    std::env::set_var("CARGO_UNSTABLE_BUILD_STD", "std");
+    
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }

--- a/macros/tests/ui/entry_preinterrupt_mismatch.stderr
+++ b/macros/tests/ui/entry_preinterrupt_mismatch.stderr
@@ -12,4 +12,14 @@ note: function defined here
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+11 | fn main(_i: bool) -> ! {
+   |         --------
    = note: this error originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused variable: `cs`
+ --> tests/ui/entry_preinterrupt_mismatch.rs:6:9
+  |
+6 | fn init(cs: CriticalSection) -> u32 {
+  |         ^^ help: if this is intentional, prefix it with an underscore: `_cs`
+  |
+  = note: `#[warn(unused_variables)]` on by default

--- a/macros/tests/ui/entry_preinterrupt_no_arg.stderr
+++ b/macros/tests/ui/entry_preinterrupt_no_arg.stderr
@@ -2,14 +2,10 @@ error[E0061]: this function takes 0 arguments but 1 argument was supplied
  --> tests/ui/entry_preinterrupt_no_arg.rs:7:42
   |
 7 | #[entry(interrupt_enable(pre_interrupt = init))]
-  | -----------------------------------------^^^^--- argument of type `CriticalSection<'_>` unexpected
+  | -----------------------------------------^^^^--- unexpected argument of type `CriticalSection<'_>`
   |
 note: function defined here
  --> tests/ui/entry_preinterrupt_no_arg.rs:5:4
   |
 5 | fn init() {}
   |    ^^^^
-help: remove the extra argument
-  |
-7 | init()
-  |

--- a/macros/tests/ui/entry_preinterrupt_return_cs.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs.stderr
@@ -1,11 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
-   | borrow later stored here
    |
    = note: this error originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/tests/ui/entry_preinterrupt_return_cs2.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs2.stderr
@@ -1,11 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs2.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
-   | borrow later stored here
    |
    = note: this error originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/tests/ui/entry_preinterrupt_return_cs3.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs3.stderr
@@ -1,11 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs3.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
-   | borrow later stored here
    |
    = note: this error originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/tests/ui/entry_preinterrupt_return_cs_cloned.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs_cloned.stderr
@@ -1,11 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs_cloned.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
-   | borrow later stored here
    |
    = note: this error originates in the attribute macro `entry` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/tests/ui/entry_preinterrupt_return_cs_cloned_static.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs_cloned_static.stderr
@@ -1,10 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs_cloned_static.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
    | argument requires that `cs` is borrowed for `'static`
    |

--- a/macros/tests/ui/entry_preinterrupt_return_cs_static.stderr
+++ b/macros/tests/ui/entry_preinterrupt_return_cs_static.stderr
@@ -1,10 +1,10 @@
-error[E0597]: `cs` does not live long enough
+error[E0597]: value does not live long enough
   --> tests/ui/entry_preinterrupt_return_cs_static.rs:10:1
    |
 10 | #[entry(interrupt_enable(pre_interrupt = init))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    | |                                              |
-   | |                                              `cs` dropped here while still borrowed
+   | |                                              value dropped here while still borrowed
    | borrowed value does not live long enough
    | argument requires that `cs` is borrowed for `'static`
    |

--- a/macros/tests/ui/interrupt_args.stderr
+++ b/macros/tests/ui/interrupt_args.stderr
@@ -1,4 +1,4 @@
-error: this attribute accepts no arguments
+error: this attribute accepts only 'wake_cpu' as an argument
   --> tests/ui/interrupt_args.rs:10:1
    |
 10 | #[interrupt(arg)]

--- a/macros/tests/ui/interrupt_wrong_import.stderr
+++ b/macros/tests/ui/interrupt_wrong_import.stderr
@@ -1,12 +1,4 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `interrupt`
-  --> tests/ui/interrupt_wrong_import.rs:11:1
-   |
-11 | #[interrupt]
-   | ^^^^^^^^^^^^ use of undeclared crate or module `interrupt`
-   |
-   = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0658]: msp430-interrupt ABI is experimental and subject to change
+error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
   --> tests/ui/interrupt_wrong_import.rs:11:1
    |
 11 | #[interrupt]
@@ -22,4 +14,13 @@ error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
 11 | #[interrupt]
    | ^^^^^^^^^^^^
    |
+   = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `interrupt`
+  --> tests/ui/interrupt_wrong_import.rs:11:1
+   |
+11 | #[interrupt]
+   | ^^^^^^^^^^^^ use of unresolved module or unlinked crate `interrupt`
+   |
+   = help: if you wanted to use a crate named `interrupt`, use `cargo add interrupt` to add it to your `Cargo.toml`
    = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/macros/tests/ui/recursion.stderr
+++ b/macros/tests/ui/recursion.stderr
@@ -1,16 +1,4 @@
-error[E0425]: cannot find function `main` in this scope
- --> tests/ui/recursion.rs:7:5
-  |
-7 |     main(cs)
-  |     ^^^^ not found in this scope
-
-error[E0425]: cannot find function, tuple struct or tuple variant `DefaultHandler` in this scope
-  --> tests/ui/recursion.rs:12:5
-   |
-12 |     DefaultHandler(cs)
-   |     ^^^^^^^^^^^^^^ not found in this scope
-
-error[E0658]: msp430-interrupt ABI is experimental and subject to change
+error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
   --> tests/ui/recursion.rs:10:1
    |
 10 | #[interrupt]
@@ -20,6 +8,12 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
    = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0425]: cannot find function `main` in this scope
+ --> tests/ui/recursion.rs:7:5
+  |
+7 |     main(cs)
+  |     ^^^^ not found in this scope
+
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
   --> tests/ui/recursion.rs:10:1
    |
@@ -27,3 +21,9 @@ error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
    | ^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find function, tuple struct or tuple variant `DefaultHandler` in this scope
+  --> tests/ui/recursion.rs:12:5
+   |
+12 |     DefaultHandler(cs)
+   |     ^^^^^^^^^^^^^^ not found in this scope

--- a/macros/tests/ui/recursion2.stderr
+++ b/macros/tests/ui/recursion2.stderr
@@ -1,16 +1,4 @@
-error[E0425]: cannot find function `main` in this scope
- --> tests/ui/recursion2.rs:7:5
-  |
-7 |     main()
-  |     ^^^^ not found in this scope
-
-error[E0425]: cannot find function, tuple struct or tuple variant `DefaultHandler` in this scope
-  --> tests/ui/recursion2.rs:12:5
-   |
-12 |     DefaultHandler()
-   |     ^^^^^^^^^^^^^^ not found in this scope
-
-error[E0658]: msp430-interrupt ABI is experimental and subject to change
+error[E0658]: the extern "msp430-interrupt" ABI is experimental and subject to change
   --> tests/ui/recursion2.rs:10:1
    |
 10 | #[interrupt]
@@ -20,6 +8,12 @@ error[E0658]: msp430-interrupt ABI is experimental and subject to change
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
    = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0425]: cannot find function `main` in this scope
+ --> tests/ui/recursion2.rs:7:5
+  |
+7 |     main()
+  |     ^^^^ not found in this scope
+
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
   --> tests/ui/recursion2.rs:10:1
    |
@@ -27,3 +21,9 @@ error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
    | ^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `interrupt` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find function, tuple struct or tuple variant `DefaultHandler` in this scope
+  --> tests/ui/recursion2.rs:12:5
+   |
+12 |     DefaultHandler()
+   |     ^^^^^^^^^^^^^^ not found in this scope


### PR DESCRIPTION
Fixes the broken CI, and accepts minor changes to error outputs that have occurred while the CI has been broken.

The `macro` workspace inherited the `msp430-none-elf` target from `.cargo/config.toml`, which caused some issues. To get around this we override that by invoking the test suite with `--target=x86_64-unknown-linux-gnu` so the trybuild runner gets built on the host architecture. Then, to ensure the tests themselves compile as msp430 binaries we have to fiddle with environment variables in the test runner so the tests are correctly built targetting the msp430 (and `build-std` is correctly passed through).